### PR TITLE
Remove invalid reference link from keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,17 +9,17 @@
 #######################################
 #	Methods	and	Functions	(KEYWORD2)
 ####################################### 
-Error	KEYWORD2	error output
-Warn	KEYWORD2	warning output
-Info	KEYWORD2	info output
-Debug	KEYWORD2	debug output
-Verbose	KEYWORD2	verbose output
-Init	KEYWORD2	initialiazing
+Error	KEYWORD2
+Warn	KEYWORD2
+Info	KEYWORD2
+Debug	KEYWORD2
+Verbose	KEYWORD2
+Init	KEYWORD2
 
 #######################################
 #	Instances	(KEYWORD2)
 #######################################
-Logging	KEYWORD2	Logging library
+Logging	KEYWORD2
 
 #######################################
 #	Constants	(LITERAL1)


### PR DESCRIPTION
The third field of keywords.txt is used to provide Arduino Language/Libraries Reference links, which are accessed from the Arduino IDE by highlighting the keyword and then selecting "Find in Reference" from the Help or right click menu. Adding values to this field that do not match any existing reference pages results in a "Could not open the URL" error.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywordstxt-format